### PR TITLE
Potentially fixes a problem with accessibility.

### DIFF
--- a/public/template/javascript/main.js
+++ b/public/template/javascript/main.js
@@ -88,7 +88,7 @@ ospnc.addResult = function(data, resHuman) {
 
     var resTemplate = '<div title="' + resHuman.title + '" id="' + resId + '" class="res-item col-sm-12 animated lightSpeedIn">' +
                       '    <div class="col-md-4"><img width="16" height="16" alt="' + data.name + '" src="' + resHuman.favicon + '" /><span>' + data.name + '</span></div>' +
-                      '    <div class="col-md-8"><i class="fa ' + resHuman.icon + '"></i><a target="_blank" title="Visit URL on checked page" href="' + data.headers.reqHost + data.headers.reqPath + '">^</a></div>' +
+                      '    <div class="col-md-8"><i class="fa ' + resHuman.icon + '" aria-hidden="true"></i><span>' + resHuman.title + '</span><a target="_blank" title="Visit URL on checked page" href="' + data.headers.reqHost + data.headers.reqPath + '">^</a></div>' +
                       '</div>';
     resContainer.append(resTemplate);
 };


### PR DESCRIPTION
When performing a search, the status of the results only shows as an icon, which is unreadable with screen readers. This fix attempts to correct this by hiding the icon to screen readers, and adding the status text so it is readable. An alternative method would be to use aria-label, but I chose to insert the name as part of the text for the rare occasion that ARIA isn't available or supported.